### PR TITLE
Easier bind addr configuration

### DIFF
--- a/lib/maru.ex
+++ b/lib/maru.ex
@@ -55,12 +55,13 @@ defmodule Maru do
   end
 
   defp endpoint_spec(proto, module, opts) do
+    bind_addr = opts[:bind_addr]
     normalized_opts =
-      opts
+      Keyword.delete(opts, :bind_addr)
       |> Keyword.merge([port: to_port(opts[:port]) || @default_ports[proto]])
-      |> Keyword.merge([ip: to_ip(opts[:bind_addr])])
-    Logger.info "Starting #{module} with Cowboy on"
-                "#{proto}://#{opts[:bind_addr]}:#{opts[:port]}"
+      |> Keyword.merge([ip: to_ip(bind_addr)])
+    Logger.info "Starting #{module} with Cowboy on " <>
+                "#{proto}://#{bind_addr}:#{opts[:port]}"
     Plug.Adapters.Cowboy.child_spec(proto, module, [], normalized_opts)
   end
 
@@ -70,7 +71,7 @@ defmodule Maru do
 
   defp to_ip(nil), do: to_ip(@default_bind_addr)
   defp to_ip(ip_addr) do
-    {ok, inet_ip} = :inet_parse.ipv4_address(String.to_charlist(ip_addr))
+    {:ok, inet_ip} = :inet_parse.ipv4_address(String.to_charlist(ip_addr))
     inet_ip
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -34,7 +34,6 @@ defmodule Maru.Mixfile do
       { :inch_ex, "~> 0.5",  only: :docs },
       { :earmark, "~> 1.0",  only: :docs },
       { :ex_doc,  "~> 0.14", only: :docs },
-      { :confex,  "~> 1.4", optional: true },
     ]
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -34,7 +34,7 @@ defmodule Maru.Mixfile do
       { :inch_ex, "~> 0.5",  only: :docs },
       { :earmark, "~> 1.0",  only: :docs },
       { :ex_doc,  "~> 0.14", only: :docs },
-      { :confex,  "~> 1.4" },
+      { :confex,  "~> 1.4", optional: true },
     ]
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -34,6 +34,7 @@ defmodule Maru.Mixfile do
       { :inch_ex, "~> 0.5",  only: :docs },
       { :earmark, "~> 1.0",  only: :docs },
       { :ex_doc,  "~> 0.14", only: :docs },
+      { :confex,  "~> 1.4" },
     ]
   end
 


### PR DESCRIPTION
This PR addresses 2 issues:

1. The bind IP address currently is only configured via ugly `{a, b, c, d}` tuples. Not only that, the server logs always state that server is running on 127.0.0.1 even if its not. Thats why, I've decided to make `bind_addr` option that is readable and possible to configure as non-tuple type. This option is handled by `maru` and translated to `{:ip, {a, b, c, d}}` option handled by lower layers. 

2. Since HTTP/HTTPS endpoints were started independently from the Application, they are not shut down when `maru` is stopped. This does not feel like expected behaviour. Therefore, all endpoints are now started in the Application's supervision tree. 

Also I've deduplicated some code in the Application's startup.