### PR TITLE
Fix testing with project containing erlang sources

### DIFF
--- a/lib/maru/test.ex
+++ b/lib/maru/test.ex
@@ -12,7 +12,7 @@ defmodule Maru.Test do
     |> to_char_list
     |> :cover.compile_beam_directory
     for module <- :cover.modules do
-      if {:__mounted_modules__, 0} in module.__info__(:functions) do
+      if {:__mounted_modules__, 0} in module.module_info(:exports) do
         Enum.each(module.__mounted_modules__, fn mounted ->
           Maru.Builder.MountLink.put_father(mounted, module)
         end)


### PR DESCRIPTION
If the project contains any erlang modules, the `Maru.Test.start/0` crashes preventing tests to start. This PR fixes that.