### PR TITLE
Don't rely on `Mix` module being present

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,10 +92,16 @@ defmodule MyAPP.API do
 end
 ```
 
-then add the `maru` to your `config/config.exs`
+Then configure `maru`:
+
 ```elixir
+# config/config.exs
 config :maru, MyAPP.API,
   http: [port: 8880]
+
+# config/test.exs
+config :maru, MyAPP.API,
+  test: true
 ```
 
 For more information, check out  [Guides](https://maru.readme.io) and [Examples](https://github.com/elixir-maru/maru_examples)

--- a/lib/maru.ex
+++ b/lib/maru.ex
@@ -39,12 +39,5 @@ defmodule Maru do
   end
 
   @doc false
-  def test_mode? do
-    case Application.get_env(:maru, :test) do
-      true  -> true
-      false -> false
-      nil   -> Mix.env == :test
-    end
-  end
-
+  def test_mode?, do: Application.get_env(:maru, :test) || false
 end

--- a/lib/maru.ex
+++ b/lib/maru.ex
@@ -39,5 +39,13 @@ defmodule Maru do
   end
 
   @doc false
-  def test_mode?, do: Application.get_env(:maru, :test) || false
+  @mix_env Mix.env
+  def test_mode? do
+    case Application.get_env(:maru, :test) do
+      true  -> true
+      false -> false
+      nil   -> @mix_env == :test
+    end
+  end
+
 end


### PR DESCRIPTION
Maru currently causes applications to break if using `Distillery` to do releases, as it assumes `Mix.env` can be called from app code.

This removes that assumption, and instructs the user to configure `maru` appropriately in the test environment.