### PR TITLE
add `:plug_status` defaults for known exceptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,9 +78,9 @@ defmodule MyAPP.API do
 
   rescue_from [MatchError, RuntimeError], with: :custom_error
 
-  rescue_from :all do
+  rescue_from :all, as: e do
     conn
-    |> put_status(500)
+    |> put_status(Plug.Exception.status(e))
     |> text("Server Error")
   end
 

--- a/lib/maru/exceptions.ex
+++ b/lib/maru/exceptions.ex
@@ -9,7 +9,7 @@ defmodule Maru.Exceptions do
         * `:illegal` raised when parse param error
     """
 
-    defexception [:reason, :param, :value]
+    defexception [:reason, :param, :value, plug_status: 400]
     def message(e) do
       "Parsing Param Error: #{e.param}"
     end
@@ -20,7 +20,7 @@ defmodule Maru.Exceptions do
     Raised when validate param failed.
     """
 
-    defexception [:param, :validator, :value, :option]
+    defexception [:param, :validator, :value, :option, plug_status: 400]
     def message(e) do
       "Validate Param Error: #{inspect e.param}"
     end
@@ -60,7 +60,7 @@ defmodule Maru.Exceptions do
         end
     """
 
-    defexception [:method, :path_info]
+    defexception [:method, :path_info, plug_status: 404]
     def message(_e) do
       "NotFound"
     end
@@ -78,7 +78,7 @@ defmodule Maru.Exceptions do
         end
     """
 
-    defexception [:method, :request_path]
+    defexception [:method, :request_path, plug_status: 405]
     def message(_e) do
       "MethodNotAllowed"
     end

--- a/test/test_test.exs
+++ b/test/test_test.exs
@@ -268,6 +268,26 @@ defmodule Maru.TestTest do
         raise "runtime_error"
         text(conn, "200")
       end
+
+      get "invalid_format" do
+        raise Maru.Exceptions.InvalidFormat
+        text(conn, "200")
+      end
+
+      get "validation" do
+        raise Maru.Exceptions.Validation
+        text(conn, "200")
+      end
+
+      get "not_found" do
+        raise Maru.Exceptions.NotFound
+        text(conn, "200")
+      end
+
+      get "method_not_allowed" do
+        raise Maru.Exceptions.MethodNotAllowed
+        text(conn, "200")
+      end
     end
 
     defmodule MWEH.M1 do
@@ -283,8 +303,8 @@ defmodule Maru.TestTest do
       use Maru.Router, make_plug: true
       mount Maru.TestTest.MWEH.M1
 
-      rescue_from :all do
-        conn |> put_status(500) |> text("500")
+      rescue_from :all, as: e do
+        conn |> put_status(Plug.Exception.status(e)) |> text("failed")
       end
     end
 
@@ -295,12 +315,20 @@ defmodule Maru.TestTest do
       def test2, do: get("/match_error").status
       def test3, do: get("/arithmetic_error").status
       def test4, do: get("/runtime_error").status
+      def test5, do: get("/invalid_format").status
+      def test6, do: get("/validation").status
+      def test7, do: get("/not_found").status
+      def test8, do: get("/method_not_allowed").status
     end
 
     assert 200 == MWEH.M2.TEST.test1
     assert 502 == MWEH.M2.TEST.test2
     assert 501 == MWEH.M2.TEST.test3
     assert 500 == MWEH.M2.TEST.test4
+    assert 400 == MWEH.M2.TEST.test5
+    assert 400 == MWEH.M2.TEST.test6
+    assert 404 == MWEH.M2.TEST.test7
+    assert 405 == MWEH.M2.TEST.test8
   end
 
   test "path_params" do


### PR DESCRIPTION
I really like where maru is going, and it is so much simpler than phoenix for APIs.

These changes add defaults for standard HTTP status codes for maru's built-in exception types (`InvalidFormat`, `Validation`, `NotFound`, and `MethodNotAllowed`). the `:plug_status` field is used by the `Plug.Exception` protocol (https://hexdocs.pm/plug/Plug.Exception.html) to map exception types to HTTP status codes. `Plug.Exception` falls back to 500 if the field doesn't exist and the exception type doesn't implement the exception protocol. This allows you to do the following:

```elixir
rescue_from :all, as: e do
  conn
  |> put_status(Plug.Exception.status(e))
  |> text("Request Failed")
end
```

The status codes can be overridden at raise time, but these defaults seemed sensible for the built-in exception types.