### PR TITLE
🐛  Expanded options for validators to allow aliased modules

### DIFF
--- a/lib/maru/utils.ex
+++ b/lib/maru/utils.ex
@@ -126,4 +126,12 @@ defmodule Maru.Utils do
   def warn(string) do
     IO.write :stderr, "\e[33mwarning: \e[0m#{string}"
   end
+
+  @doc false
+  def expand_alias(ast, caller) do
+    Macro.prewalk(ast, fn
+      {:__aliases__, _, _} = module -> Macro.expand(module, caller)
+      other -> other
+    end)
+  end
 end


### PR DESCRIPTION
Fixed https://github.com/elixir-maru/maru/issues/88.

Doing the "caller passing dance" again!

Modified `Maru.Builder.Params.parse` to take the caller and use it to expand the ast for options passed to param validators. This way we can use alias there.

**Note**: I've modified `parse` to accept 2 parameters, the caller being the last one. Although I've changed  all the calls to `parse/1` to use `parse/2` and pass the caller, I was getting errors about some piece of code still wanting to call `parse/1` which did not exist anymore. So I've defined `parse/1` to proxy to `parse/2` which "solved" the issue. This is a hack, I don't know who is still using `parse/1` and even when the tests still pass I might have broken something.