### PR TITLE
Upgrade to Cowboy 2

### DIFF
--- a/lib/maru/supervisor.ex
+++ b/lib/maru/supervisor.ex
@@ -40,7 +40,7 @@ defmodule Maru.Supervisor do
         "#{proto}://#{:inet_parse.ntoa(bind_addr)}:#{opts[:port]}"
     )
 
-    Plug.Adapters.Cowboy.child_spec(proto, module, [], normalized_opts)
+    Plug.Adapters.Cowboy2.child_spec(proto, module, [], normalized_opts)
   end
 
   defp to_port(nil), do: nil

--- a/mix.exs
+++ b/mix.exs
@@ -27,8 +27,8 @@ defmodule Maru.Mixfile do
 
   defp deps do
     [
-      {:cowboy, "~> 1.1"},
-      {:plug, "~> 1.4"},
+      {:cowboy, "~> 2.2"},
+      {:plug, "~> 1.5"},
       {:poison, "~> 3.0"},
       {:inch_ex, "~> 0.5", only: :docs},
       {:earmark, "~> 1.2", only: :docs},


### PR DESCRIPTION
This pull-request is about upgrading Maru to use the latest major version of Cowboy (i.e. 2.X).

https://ninenines.eu/articles/cowboy-2.0.0/

The Plug upgrade is just a byproduct of upgrading Cowboy. The Cowboy2 adapter is new in Plug 1.5.
