### PR TITLE
Use List.flatten/1 instead of Enum.concat/1

### DIFF
--- a/lib/maru/builder/plug_router.ex
+++ b/lib/maru/builder/plug_router.ex
@@ -38,7 +38,7 @@ defmodule PlugRouter do
         version_adapter.get_version_plug(version_config),
         [{:route, [], true}, {Maru.Plugs.NotFound, [], true}]
       ]
-      |> Enum.concat()
+      |> List.flatten()
       |> Enum.reverse()
 
     {conn, body} = Plug.Builder.compile(env, pipeline, [])


### PR DESCRIPTION
This change is required by https://github.com/efcasado/maru_swagger/commit/e034cacd6fc12b285ae844ca49f75e518cbc8c33#diff-2c9d1a519fe1537e1425a947f40723cdR17. Without this change, we cannot use the `@plugs_before` module attribute to include a list of plugs.