### PR TITLE
Allow URI to be used for 'redirect'.

### DIFF
--- a/lib/maru/response.ex
+++ b/lib/maru/response.ex
@@ -21,10 +21,11 @@ defmodule Maru.Response do
   @doc """
   Make response by url redirect.
   """
+  def redirect(conn, url, opts \\ [])
   def redirect(%Plug.Conn{} = conn, %URI{} = url, opts) do
     redirect(conn, URI.to_string(url), opts)
   end
-  def redirect(%Plug.Conn{} = conn, url, opts \\ []) do
+  def redirect(%Plug.Conn{} = conn, url, opts) do
     code = (opts[:permanent] && 301) || 302
 
     conn

--- a/lib/maru/response.ex
+++ b/lib/maru/response.ex
@@ -21,6 +21,9 @@ defmodule Maru.Response do
   @doc """
   Make response by url redirect.
   """
+  def redirect(%Plug.Conn{} = conn, %URI{} = url, opts) do
+    redirect(conn, URI.to_string(url), opts)
+  end
   def redirect(%Plug.Conn{} = conn, url, opts \\ []) do
     code = (opts[:permanent] && 301) || 302
 

--- a/test/maru_response_test.exs
+++ b/test/maru_response_test.exs
@@ -18,6 +18,14 @@ defmodule Maru.ResponseTest do
     assert conn.halted
   end
 
+  test "redirect allow use of URI" do
+    sample_uri = URI.parse("http://example.com/?foo=bar")
+    conn = conn(:get, "/") |> redirect(sample_uri, permanent: true)
+    assert {"location", "http://example.com/?foo=bar"} in conn.resp_headers
+    assert 301 == conn.status
+    assert conn.halted
+  end
+
   test "conn in process dict" do
     put_maru_conn(1)
     assert 1 == get_maru_conn()


### PR DESCRIPTION
I tend to do a lot of URI validation when I'm handling redirects.
This change allows you to pass in a URI to use for redirecting.
It's a bit more semantically correct (and helps with a bit of type-checking).